### PR TITLE
base64 encode raw tx sig

### DIFF
--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -60,7 +60,7 @@ export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promis
         `with account ${keypair.address}?`
   );
   if (confirmation) {
-    return transactionSignRaw(rawMessage, keypair.privateKey).toString("hex");
+    return transactionSignRaw(rawMessage, keypair.privateKey).toString("base64");
   }
   return null;
 }


### PR DESCRIPTION
The lotus node is expecting base64 encoded strings. This was tested with the Glif wallet, and I'm successfully sending more complex messages with this change!