### PR TITLE
Return confirmation info on message signing

### DIFF
--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -3,7 +3,8 @@ import {
   MetamaskFilecoinRpcRequest,
   MessageRequest,
   SignedMessage,
-  SnapConfig, MessageGasEstimate
+  SignMessageResponse,
+  SnapConfig, MessageGasEstimate, SignRawMessageResponse
 } from "@chainsafe/filsnap-types";
 import {MetamaskFilecoinSnap} from "./snap";
 
@@ -36,11 +37,11 @@ export async function configure(this: MetamaskFilecoinSnap, configuration: SnapC
   return await sendSnapMethod({method: "fil_configure", params: {configuration: configuration}}, this.snapId);
 }
 
-export async function signMessage(this: MetamaskFilecoinSnap, message: MessageRequest): Promise<SignedMessage> {
+export async function signMessage(this: MetamaskFilecoinSnap, message: MessageRequest): Promise<SignMessageResponse> {
   return await sendSnapMethod({method: "fil_signMessage", params: {message: message}}, this.snapId);
 }
 
-export async function signMessageRaw(this: MetamaskFilecoinSnap, rawMessage: string): Promise<string> {
+export async function signMessageRaw(this: MetamaskFilecoinSnap, rawMessage: string): Promise<SignRawMessageResponse> {
   return await sendSnapMethod({method: "fil_signMessageRaw", params: {message: rawMessage}}, this.snapId);
 }
 

--- a/packages/example/src/components/SignMessage/SignMessage.tsx
+++ b/packages/example/src/components/SignMessage/SignMessage.tsx
@@ -20,10 +20,12 @@ export const SignMessage = (props: SignMessageProps) => {
     const onSubmit = async () => {
         if(textFieldValue && props.api) {
             const rawMessage = toHex(textFieldValue, {addPrefix: true});
-            const signature = await props.api.signMessageRaw(rawMessage);
+            const sigResponse = await props.api.signMessageRaw(rawMessage);
+            if(sigResponse.confirmed && sigResponse.error == null) {
+                setModalBody(sigResponse.signature);
+                setModalOpen(true);
+            }
             setTextFieldValue("");
-            setModalBody(signature);
-            setModalOpen(true);
         }
     };
 

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -75,16 +75,24 @@ export const Transfer: React.FC<ITransferProps> = ({network, api, onNewMessageCa
     const onSubmit = useCallback(async () => {
         if (amount && recipient && api) {
             // Temporary signature method until sending is implemented
-            const signedMessage = await api.signMessage({
+            const signedMessageResponse = await api.signMessage({
                 to: recipient,
                 value: BigInt(amount).toString(),
                 gaslimit: Number(gasLimit),
                 gasfeecap: gasFeeCap,
                 gaspremium: gasPremium
             });
-            showAlert("info", `Message signature: ${signedMessage.signature.data}`);
-            const txResult = await api.sendMessage(signedMessage);
-            showAlert("info", `Message sent with cid: ${txResult.cid}`);
+
+            if(signedMessageResponse.error != null) {
+                showAlert("error", "Error on signing message");
+            } else if(signedMessageResponse.error == null && !signedMessageResponse.confirmed) {
+                showAlert("info", "Signing message declined");
+            } else {
+                showAlert("info", `Message signature: ${signedMessageResponse.signedMessage.signature.data}`);
+                const txResult = await api.sendMessage(signedMessageResponse.signedMessage);
+                showAlert("info", `Message sent with cid: ${txResult.cid}`);
+            }
+
             // clear form
             setAmount("");
             setRecipient("");

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -16,7 +16,7 @@
     "type-check:watch": "npm run type-check -- --watch",
     "build": "yarn run build:tsc && yarn run build:snap",
     "build:tsc": "tsc -p tsconfig.build.json --pretty --outDir build",
-    "build:snap": "yarn build:snap:bundle && yarn build:snap:postprocess && yarn build:snap:eval",
+    "build:snap": "yarn build:snap:bundle && yarn build:snap:postprocess && yarn build:snap:eval && mm-snap manifest --fix",
     "build:snap:bundle": "mm-snap build --verboseErrors  --stripComments --eval false",
     "build:snap:postprocess": "node ./post-process.js",
     "build:snap:eval": "mm-snap eval -b dist/bundle.js --verboseErrors",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -16,7 +16,7 @@
     "type-check:watch": "npm run type-check -- --watch",
     "build": "yarn run build:tsc && yarn run build:snap",
     "build:tsc": "tsc -p tsconfig.build.json --pretty --outDir build",
-    "build:snap": "yarn build:snap:bundle && yarn build:snap:postprocess && yarn build:snap:eval && mm-snap manifest --fix",
+    "build:snap": "yarn build:snap:bundle && yarn build:snap:postprocess && yarn build:snap:eval",
     "build:snap:bundle": "mm-snap build --verboseErrors  --stripComments --eval false",
     "build:snap:postprocess": "node ./post-process.js && mm-snap manifest --fix",
     "build:snap:eval": "mm-snap eval -b dist/bundle.js --verboseErrors",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "uueLzOvb0owglnqck1pCL61GWVWtfjkgkVuk24oPW6k=",
+    "shasum": "hiMpuSeODKu7WB029fyNNEIVXhDbQfWaNd/cXCzQ4ss=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "cdLDlA1bQj0g46Tne00vNC9LYY5l82fw8D+iv8Xz1zk=",
+    "shasum": "uueLzOvb0owglnqck1pCL61GWVWtfjkgkVuk24oPW6k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "hiMpuSeODKu7WB029fyNNEIVXhDbQfWaNd/cXCzQ4ss=",
+    "shasum": "iAyxiP8V7yeet7Rh9qNUkOnnH4iv6sRvc+weBwbGtDo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -3,68 +3,82 @@ import {Wallet} from "../interfaces";
 import {getKeyPair} from "../filecoin/account";
 import {showConfirmationDialog} from "../util/confirmation";
 import {LotusRpcApi} from "../filecoin/types";
-import {MessageRequest} from "@chainsafe/filsnap-types";
+import {MessageRequest, SignMessageResponse, SignRawMessageResponse} from "@chainsafe/filsnap-types";
 
 export async function signMessage(
   wallet: Wallet, api: LotusRpcApi, messageRequest: MessageRequest
-): Promise<SignedMessage> {
-  const keypair = await getKeyPair(wallet);
-  // extract gas params
-  const gl = messageRequest.gaslimit && messageRequest.gaslimit !== 0 ? messageRequest.gaslimit : 0;
-  const gp = messageRequest.gaspremium && messageRequest.gaspremium !== "0" ? messageRequest.gaspremium : "0";
-  const gfc = messageRequest.gasfeecap && messageRequest.gasfeecap !== "0" ? messageRequest.gasfeecap : "0";
-  const nonce = messageRequest.nonce ?? Number(await api.mpoolGetNonce(keypair.address));
-  // create message object
-  const message: Message = {
-    from: keypair.address,
-    gasfeecap: gfc,
-    gaslimit: gl,
-    gaspremium: gp,
-    method: 0, // code for basic transaction
-    nonce,
-    params: "",
-    to: messageRequest.to,
-    value: messageRequest.value,
-  };
-  // estimate gas usage if gas params not provided
-  if (message.gaslimit === 0 && message.gasfeecap === "0" && message.gaspremium === "0") {
-    message.gaslimit = await api.gasEstimateGasLimit(message, null);
-    const messageEstimate = await api.gasEstimateMessageGas(message, {MaxFee: "0"}, null);
-    message.gaspremium = messageEstimate.GasPremium;
-    message.gasfeecap = messageEstimate.GasFeeCap;
+): Promise<SignMessageResponse> {
+  try {
+    const keypair = await getKeyPair(wallet);
+    // extract gas params
+    const gl = messageRequest.gaslimit && messageRequest.gaslimit !== 0 ? messageRequest.gaslimit : 0;
+    const gp = messageRequest.gaspremium && messageRequest.gaspremium !== "0" ? messageRequest.gaspremium : "0";
+    const gfc = messageRequest.gasfeecap && messageRequest.gasfeecap !== "0" ? messageRequest.gasfeecap : "0";
+    const nonce = messageRequest.nonce ?? Number(await api.mpoolGetNonce(keypair.address));
+    // create message object
+    const message: Message = {
+      from: keypair.address,
+      gasfeecap: gfc,
+      gaslimit: gl,
+      gaspremium: gp,
+      method: 0, // code for basic transaction
+      nonce,
+      params: "",
+      to: messageRequest.to,
+      value: messageRequest.value,
+    };
+    // estimate gas usage if gas params not provided
+    if (message.gaslimit === 0 && message.gasfeecap === "0" && message.gaspremium === "0") {
+      message.gaslimit = await api.gasEstimateGasLimit(message, null);
+      const messageEstimate = await api.gasEstimateMessageGas(message, {MaxFee: "0"}, null);
+      message.gaspremium = messageEstimate.GasPremium;
+      message.gasfeecap = messageEstimate.GasFeeCap;
+    }
+    // show confirmation
+    const confirmation = await showConfirmationDialog(
+      wallet,
+      {
+        prompt: `Do you want to sign this message?`,
+        textAreaContent: `from: ${message.from}\n` +
+          `to: ${message.to}\n` +
+          `value:${message.value}\n` +
+          `gas limit:${message.gaslimit}\n` +
+          `gas fee cap:${message.gasfeecap}\n` +
+          `gas premium: ${message.gaspremium}\n` +
+          `with account ${keypair.address}?`
+      },
+    );
+
+    var sig: SignedMessage
+    if (confirmation) {
+      sig = transactionSign(message, keypair.privateKey)
+    }
+
+    return {confirmed: confirmation, signedMessage: sig, error: null}
+  } catch (e) {
+    return {confirmed: false, signedMessage: null, error: e}
   }
-  // show confirmation
-  const confirmation = await showConfirmationDialog(
-    wallet,
-    {
-      prompt: `Do you want to sign this message?`,
-      textAreaContent: `from: ${message.from}\n` +
-        `to: ${message.to}\n` +
-        `value:${message.value}\n` +
-        `gas limit:${message.gaslimit}\n` +
-        `gas fee cap:${message.gasfeecap}\n` +
-        `gas premium: ${message.gaspremium}\n` +
-        `with account ${keypair.address}?`
-    },
-  );
-  if (confirmation) {
-    return transactionSign(message, keypair.privateKey);
-  }
-  return null;
 }
 
-export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promise<string> {
-  const keypair = await getKeyPair(wallet);
-  const confirmation = await showConfirmationDialog(
-    wallet,
-    {
-      description: `It will be signed with address: ${keypair.address}`,
-      prompt: `Do you want to sign this message?`,
-      textAreaContent: rawMessage,
+export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promise<SignRawMessageResponse> {
+  try {
+    const keypair = await getKeyPair(wallet);
+    const confirmation = await showConfirmationDialog(
+      wallet,
+      {
+        description: `It will be signed with address: ${keypair.address}`,
+        prompt: `Do you want to sign this message?`,
+        textAreaContent: rawMessage,
+      }
+    );
+
+    var sig: string
+    if (confirmation) {
+      sig = transactionSignRaw(rawMessage, keypair.privateKey).toString("base64");
     }
-  );
-  if (confirmation) {
-    return transactionSignRaw(rawMessage, keypair.privateKey).toString("base64");
+
+    return {confirmed: confirmation, signature: sig, error: null}
+  } catch (e) {
+    return {confirmed: false, signature: null, error: e}
   }
-  return null;
 }

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -49,14 +49,14 @@ export async function signMessage(
       },
     );
 
-    let sig: SignedMessage;
+    let sig: SignedMessage = null;
     if (confirmation) {
       sig = transactionSign(message, keypair.privateKey);
     }
 
     return {confirmed: confirmation, error: null, signedMessage: sig};
   } catch (e) {
-    return {confirmed: false, error: null, signedMessage: null};
+    return {confirmed: false, error: e, signedMessage: null};
   }
 }
 
@@ -72,7 +72,7 @@ export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promis
       }
     );
 
-    let sig: string;
+    let sig: string = null;
     if (confirmation) {
       sig = transactionSignRaw(rawMessage, keypair.privateKey).toString("base64");
     }

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -49,14 +49,14 @@ export async function signMessage(
       },
     );
 
-    var sig: SignedMessage
+    let sig: SignedMessage;
     if (confirmation) {
-      sig = transactionSign(message, keypair.privateKey)
+      sig = transactionSign(message, keypair.privateKey);
     }
 
-    return {confirmed: confirmation, signedMessage: sig, error: null}
+    return {confirmed: confirmation, error: null, signedMessage: sig};
   } catch (e) {
-    return {confirmed: false, signedMessage: null, error: e}
+    return {confirmed: false, error: null, signedMessage: null};
   }
 }
 
@@ -72,13 +72,13 @@ export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promis
       }
     );
 
-    var sig: string
+    let sig: string;
     if (confirmation) {
       sig = transactionSignRaw(rawMessage, keypair.privateKey).toString("base64");
     }
 
-    return {confirmed: confirmation, signature: sig, error: null}
+    return {confirmed: confirmation, error: null, signature: sig};
   } catch (e) {
-    return {confirmed: false, signature: null, error: e}
+    return {confirmed: false, error: e, signature: null};
   }
 }

--- a/packages/snap/test/unit/rpc/signMessage.test.ts
+++ b/packages/snap/test/unit/rpc/signMessage.test.ts
@@ -95,12 +95,14 @@ describe('Test rpc handler function: signMessage', function () {
             gaslimit: 1000
         };
         
-        const signedMessage = await signMessage(walletStub, apiStub, messageRequestWithGasParams);
+        const response = await signMessage(walletStub, apiStub, messageRequestWithGasParams);
         
         expect(walletStub.rpcStubs.snap_confirm).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_getBip44Entropy_461).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_manageState).to.have.been.calledOnce;
-        expect(signedMessage).to.be.null;
+        expect(response.signedMessage).to.be.null;
+        expect(response.error).to.be.null;
+        expect(response.confirmed).to.be.false;
     });
 
     it('should fail signing on invalid message ', async function () {
@@ -115,8 +117,10 @@ describe('Test rpc handler function: signMessage', function () {
 
         apiStub.mpoolGetNonce.returns("0");
 
-        expect(async () => {
-            return await signMessage(walletStub, apiStub, invalidMessage);
-        }).to.throw;
+        const response = await signMessage(walletStub, apiStub, invalidMessage);
+
+        expect(response.signedMessage).to.be.null;
+        expect(response.error).to.not.be.null;
+        expect(response.confirmed).to.be.false;
     });
 });

--- a/packages/snap/test/unit/rpc/signMessage.test.ts
+++ b/packages/snap/test/unit/rpc/signMessage.test.ts
@@ -44,7 +44,7 @@ describe('Test rpc handler function: signMessage', function () {
         apiStub.gasEstimateGasLimit.returns(1000);
         apiStub.gasEstimateMessageGas.returns({GasPremium: "10", GasFeeCap: "10"});
 
-        const signedMessage = await signMessage(walletStub, apiStub, messageRequest);
+        const response = await signMessage(walletStub, apiStub, messageRequest);
         
         expect(walletStub.rpcStubs.snap_confirm).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_getBip44Entropy_461).to.have.been.calledOnce;
@@ -52,9 +52,9 @@ describe('Test rpc handler function: signMessage', function () {
         expect(apiStub.mpoolGetNonce).to.have.been.calledOnce;
         expect(apiStub.gasEstimateGasLimit).to.have.been.calledOnce;
         expect(apiStub.gasEstimateMessageGas).to.have.been.calledOnce;
-        expect(signedMessage.message).to.be.deep.eq(fullMessage);
-        expect(signedMessage.signature.data).to.not.be.empty;
-        expect(signedMessage.signature.type).to.be.eq(1);
+        expect(response.signedMessage.message).to.be.deep.eq(fullMessage);
+        expect(response.signedMessage.signature.data).to.not.be.empty;
+        expect(response.signedMessage.signature.type).to.be.eq(1);
     });
 
     it('should successfully sign valid message with gas params on positive prompt', async function () {
@@ -71,14 +71,14 @@ describe('Test rpc handler function: signMessage', function () {
             gaslimit: 1000,
             nonce: 1
         };
-        const signedMessage = await signMessage(walletStub, apiStub, messageRequestWithGasParams);
+        const response = await signMessage(walletStub, apiStub, messageRequestWithGasParams);
         expect(walletStub.rpcStubs.snap_confirm).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_getBip44Entropy_461).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_manageState).to.have.been.calledOnce;
-        expect(signedMessage.message).to.be.deep.eq({...fullMessage, nonce: 1});
+        expect(response.signedMessage.message).to.be.deep.eq({...fullMessage, nonce: 1});
         expect(apiStub.mpoolGetNonce).to.have.not.been.called;
-        expect(signedMessage.signature.data).to.not.be.empty;
-        expect(signedMessage.signature.type).to.be.eq(1);
+        expect(response.signedMessage.signature.data).to.not.be.empty;
+        expect(response.signedMessage.signature.type).to.be.eq(1);
     });
 
     it('should cancel signing on negative prompt', async function () {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -126,6 +126,18 @@ export interface MessageSignature {
   type: number;
 }
 
+export interface SignMessageResponse {
+  signedMessage: SignedMessage
+  confirmed: boolean
+  error: Error
+}
+
+export interface SignRawMessageResponse {
+  signature: string
+  confirmed: boolean
+  error: Error
+}
+
 export interface MessageRequest {
   to: string;
   value: string;
@@ -156,8 +168,8 @@ export interface FilecoinSnapApi {
   getBalance(): Promise<string>;
   exportPrivateKey(): Promise<string>;
   configure(configuration: Partial<SnapConfig>): Promise<void>;
-  signMessage(message: MessageRequest): Promise<SignedMessage>;
-  signMessageRaw(message: string): Promise<string>;
+  signMessage(message: MessageRequest): Promise<SignMessageResponse>;
+  signMessageRaw(message: string): Promise<SignRawMessageResponse>;
   sendMessage(signedMessage: SignedMessage): Promise<MessageStatus>;
   getMessages(): Promise<MessageStatus[]>;
   calculateGasForMessage(message: MessageRequest): Promise<MessageGasEstimate>;


### PR DESCRIPTION
### Description
Based on #102 I expanded information that is being returned when signing messages. Now both methods for signing messages return objects with info on _confirmation_, _error_, and _signature_. Interfaces definition can be found below.

```ts
export interface SignMessageResponse {
  signedMessage: SignedMessage
  confirmed: boolean
  error: Error
}

export interface SignRawMessageResponse {
  signature: string
  confirmed: boolean
  error: Error
}
```

This can be used to properly handle specific cases, example can be seen in the demo app. 
When sending a transaction, different notifications will be shown depending on if the user approved the message signing.

### Issues
Closes #102