### PR TITLE
Fix snap build script

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -18,7 +18,7 @@
     "build:tsc": "tsc -p tsconfig.build.json --pretty --outDir build",
     "build:snap": "yarn build:snap:bundle && yarn build:snap:postprocess && yarn build:snap:eval",
     "build:snap:bundle": "mm-snap build --verboseErrors  --stripComments --eval false",
-    "build:snap:postprocess": "node ./post-process.js",
+    "build:snap:postprocess": "node ./post-process.js && mm-snap manifest --fix",
     "build:snap:eval": "mm-snap eval -b dist/bundle.js --verboseErrors",
     "watch": "concurrently  --raw --kill-others \"yarn run watch:tsc\" \"yarn run watch:snap\" \"yarn run serve\"",
     "watch:tsc": "yarn run build:tsc --watch",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "cdLDlA1bQj0g46Tne00vNC9LYY5l82fw8D+iv8Xz1zk=",
+    "shasum": "HGt2nQCLrHrBSJQyQrsh2OJZd3Ph+pur84ZUK9GxBqQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
We were missing a `manifest --fix` call in the `postprocess` step.