### PR TITLE
Load snap id from env

### DIFF
--- a/packages/example/.env.sample
+++ b/packages/example/.env.sample
@@ -1,0 +1,1 @@
+REACT_APP_SNAP_ID=local:http://localhost:8081

--- a/packages/example/.gitignore
+++ b/packages/example/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -13,7 +13,7 @@ declare global {
     }
 }
 
-export const snapId = 'local:http://localhost:8081';
+export const defaultSnapId = 'local:http://localhost:8081';
 
 let isInstalled: boolean = false;
 
@@ -23,6 +23,7 @@ export interface SnapInitializationResponse {
 }
 
 export async function installFilecoinSnap(): Promise<SnapInitializationResponse> {
+    const snapId = process.env.REACT_APP_SNAP_ID ? process.env.REACT_APP_SNAP_ID : defaultSnapId
     try {
         console.log('Attempting to connect to snap...');
         const metamaskFilecoinSnap = await enableFilecoinSnap({network: "f"}, snapId);


### PR DESCRIPTION
Our example app now loads `SnapId` from env variable `REACT_APP_SNAP_ID` and defaults to `local:http://localhost:8081`