### PR TITLE
fix: show falsy fields in `signMessage` prompt

### DIFF
--- a/packages/snap/@types/filecoin-signing-tools/index.d.ts
+++ b/packages/snap/@types/filecoin-signing-tools/index.d.ts
@@ -1,51 +1,51 @@
 declare module "@zondax/filecoin-signing-tools/js" {
 
-    export class ExtendedKey {
-        constructor(privateKey: Buffer, testnet?: boolean)
-        address: string;
-        privateKey: Buffer | Uint8Array;
-        publicKey: Buffer | Uint8Array;
-        // getters
-        get public_raw(): Uint8Array;
-        get private_raw(): Uint8Array;
-        get public_hexstring(): string;
-        get private_hexstring(): string;
-        get public_base64(): string;
-        get private_base64(): string;
+  export class ExtendedKey {
+    constructor(privateKey: Buffer, testnet?: boolean)
+    address: string;
+    privateKey: Buffer | Uint8Array;
+    publicKey: Buffer | Uint8Array;
+    // getters
+    get public_raw(): Uint8Array;
+    get private_raw(): Uint8Array;
+    get public_hexstring(): string;
+    get private_hexstring(): string;
+    get public_base64(): string;
+    get private_base64(): string;
+  }
+
+  export interface Message {
+    to: string;
+    from: string;
+    nonce: number;
+    value: string;
+    gasfeecap: string;
+    gaspremium: string;
+    gaslimit: number;
+    method: number;
+    params?: string;
+  }
+
+  export interface SignedMessage {
+    message: Message;
+    signature: {
+      data: string;
+      type: number;
     }
+  }
 
-    export interface Message {
-        to: string;
-        from: string;
-        nonce: number;
-        value: string;
-        gasfeecap: string;
-        gaspremium: string;
-        gaslimit: number;
-        method: number;
-        params?: string;
-    }
+  export function generateMnemonic(): string;
+  export function keyDeriveFromSeed(seed: string, path: string): ExtendedKey;
 
-    export interface SignedMessage {
-        message: Message;
-        signature: {
-            data: string;
-            type: number;
-        }
-    }
+  export function transactionSerializeRaw(transaction: Message): Buffer;
+  export function transactionSerialize(transaction: Message): string;
 
-    export function generateMnemonic(): string;
-    export function keyDeriveFromSeed(seed: string, path: string): ExtendedKey;
+  export function transactionSignRaw(unsignedMessage: Message | string, privateKey: string): Buffer;
+  export function transactionSign(unsignedMessage: Message, privateKey: string): SignedMessage;
 
-    export function transactionSerializeRaw(transaction: Message): Buffer;
-    export function transactionSerialize(transaction: Message): string;
+  export function keyRecover(privateKey: Buffer, testnet: boolean): ExtendedKey;
 
-    export function transactionSignRaw(unsignedMessage: Message | string, privateKey: string): Buffer;
-    export function transactionSign(unsignedMessage: Message, privateKey: string): SignedMessage;
-
-    export function keyRecover(privateKey: Buffer, testnet: boolean): ExtendedKey;
-
-    export interface Buffer {
-        toString(encoding: "utf8" | "hex" | "binary" | "base64" | "ascii"): string;
-    }
+  export interface Buffer {
+    toString(encoding: "utf8" | "hex" | "binary" | "base64" | "ascii"): string;
+  }
 }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "b8r5tRhmxX7VLYW/Q7XKfAzbqtWKJfJQ6WpUMQe208w=",
+    "shasum": "DwrsJugbH+FgZyhMHxtihw2RlKrW3hYT5XYIJkt5xK0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "DwrsJugbH+FgZyhMHxtihw2RlKrW3hYT5XYIJkt5xK0=",
+    "shasum": "upyI4dkSj0mtx/Vf2wAbymVqJW7xZmhzQlT189rXznI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -50,8 +50,7 @@ export async function signMessage(
           [
             {message: 'to:', value: message.to},
             {message: 'from:', value: message.from},
-            {message: 'value:', value: message.value !== '0'
-              && `${new FilecoinNumber(message.value, 'attofil').toFil()} FIL`},
+            {message: 'value:', value: `${new FilecoinNumber(message.value, 'attofil').toFil()} FIL`},
             {message: 'method:', value: message.method},
             {message: 'params:', value: message.params},
             {message: 'gas limit:', value: `${message.gaslimit} aFIL`},

--- a/packages/snap/src/util/messageCreator.ts
+++ b/packages/snap/src/util/messageCreator.ts
@@ -4,6 +4,5 @@ interface Message {
 }
 
 export const messageCreator = (messages: Message[]): string => messages
-  .filter(({ value }) => !!value)
   .map(({ message, value,}) => message + ' ' + value)
   .join('\n');


### PR DESCRIPTION
Closes #148 