### PR TITLE
fix: issues after MetaMask update with breaking changes

### DIFF
--- a/packages/adapter/README.md
+++ b/packages/adapter/README.md
@@ -16,7 +16,8 @@ Adapter has only exposed function for installing Filecoin snap.
 ```typescript
 async function enableFilecoinSnap(
   config: Partial<SnapConfig>, 
-  snapOrigin?: string
+  snapOrigin?: string, 
+  version?: string
 ): Promise<MetamaskFilecoinSnap> 
 ```
 

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -27,13 +27,14 @@ export type SnapInstallationParamNames = "version" | string;
  *
  * @param config - SnapConfig
  * @param snapOrigin
+ * @param version
  *
  * @return MetamaskFilecoinSnap - adapter object that exposes snap API
  */
 export async function enableFilecoinSnap(
   config: Partial<SnapConfig>,
   snapOrigin?: string,
-  snapInstallationParams: Record<SnapInstallationParamNames, unknown> = {}
+  version?: string
 ): Promise<MetamaskFilecoinSnap> {
   const snapId = snapOrigin ?? defaultSnapOrigin;
 
@@ -53,14 +54,10 @@ export async function enableFilecoinSnap(
   if (!isInstalled) {
     // // enable snap
     await window.ethereum.request({
-      method: "wallet_enable",
-      params: [
-        {
-          [`wallet_snap_${snapId}`]: {
-            ...snapInstallationParams,
-          },
-        },
-      ],
+      method: "wallet_requestSnaps",
+      params: {
+        [snapId]: { version },
+      },
     });
   }
 

--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -16,7 +16,7 @@ async function sendSnapMethod<T>(
 ): Promise<T> {
   return await window.ethereum.request({
     method: snapId,
-    params: [request],
+    params: request,
   });
 }
 

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -7,7 +7,7 @@ declare global {
       isUnlocked: Promise<boolean>;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       request: <T>(
-        request: SnapRpcMethodRequest | { method: string; params?: any[] }
+        request: SnapRpcMethodRequest | { method: string; params?: any }
       ) => Promise<T>;
       on: (eventName: unknown, callback: unknown) => unknown;
     };

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -26,7 +26,7 @@ export async function initiateFilecoinSnap(): Promise<SnapInitializationResponse
     const snapId = process.env.REACT_APP_SNAP_ID ? process.env.REACT_APP_SNAP_ID : defaultSnapId
     try {
         console.log('Attempting to connect to snap...');
-        const metamaskFilecoinSnap = await enableFilecoinSnap({network: "f"}, snapId, {version: "latest"});
+        const metamaskFilecoinSnap = await enableFilecoinSnap({network: "f"}, snapId);
         isInstalled = true;
         console.log('Snap installed!');
         return {isSnapInstalled: true, snap: metamaskFilecoinSnap};

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -6,7 +6,7 @@ declare global {
         ethereum: {
             isMetaMask: boolean;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            send: <T>(request: SnapRpcMethodRequest | {method: string; params?: any[]}) => Promise<T>;
+            send: <T>(request: SnapRpcMethodRequest | {method: string; params?: any}) => Promise<T>;
             on: (eventName: unknown, callback: unknown) => unknown;
             // requestIndex: () => Promise<{getSnapApi: (origin: string) => Promise<FilecoinApi>}>;
         }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -17,6 +17,10 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true,
+      "snaps": false
+    },
     "endowment:network-access": {},
     "snap_confirm": {},
     "snap_getBip44Entropy": [

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -68,9 +68,9 @@ export type MetamaskFilecoinRpcRequest =
 
 type Method = MetamaskFilecoinRpcRequest["method"];
 
-export interface WalletEnableRequest {
-  method: "wallet_enable";
-  params: object[];
+export interface RequestSnapsRequest {
+  method: "wallet_requestSnaps";
+  params: Record<string, { version?: string }>;
 }
 
 export interface GetSnapsRequest {
@@ -83,7 +83,7 @@ export interface SnapRpcMethodRequest {
 }
 
 export type MetamaskRpcRequest =
-  | WalletEnableRequest
+  | RequestSnapsRequest
   | GetSnapsRequest
   | SnapRpcMethodRequest;
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -78,8 +78,8 @@ export interface GetSnapsRequest {
 }
 
 export interface SnapRpcMethodRequest {
-  method: string;
-  params: [MetamaskFilecoinRpcRequest];
+  method: `wallet_snap_${string}`;
+  params: MetamaskFilecoinRpcRequest;
 }
 
 export type MetamaskRpcRequest =


### PR DESCRIPTION
Fixes the following issues:

- The `wallet_enable` method has been replaced with `wallet_requestSnaps`, passing params as an object, not an array. https://docs.metamask.io/guide/snaps-rpc-api.html#wallet-requestsnaps
- Calls to RPC method `wallet_snap_*` should now be sent with the params as a single object, not as an array. https://docs.metamask.io/guide/snaps-rpc-api.html#wallet-snap
- The `endowment:rpc` permission should now be granted to the snap in order to receive RPC calls. My assumption is that only the `dapps` property needs to be true and not the `snaps` property. https://docs.metamask.io/guide/snaps-permissions.html#endowment-rpc

Something seems to go wrong with linking the packages when running the demo locally, since I get the following error:
```
Failed to compile.
./src/containers/MetaMaskConnector/MetaMaskConnector.tsx
Module not found: Can't resolve '@chainsafe/filsnap-adapter' in 'C:\dev\chainsafe\filsnap\packages\example\src\containers\MetaMaskConnector'
```

However, I've been able to test the RPC changes in my local project and that seems to work fine.
The only problem is that I still get the error about the snap permissions and I'm not sure if we can even test that properly without first deploying the new snap version and installing it in MetaMask.