### PR TITLE
fix: gaslimit

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "8Vx7jaoJt4mO71SjaNMmmlINtDrBOS6mVxskBxMw4sg=",
+    "shasum": "Nh3xrs/2St4UnkSAULCq7jBP0dRRnnBi3WxwSvjwJrA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Chainsafe/filsnap.git"
   },
   "source": {
-    "shasum": "Nh3xrs/2St4UnkSAULCq7jBP0dRRnnBi3WxwSvjwJrA=",
+    "shasum": "Z7lh6iD1yjfKES/WutUyxepg5Dgp8Xjo3kivsz9vpwc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpc/estimateMessageGas.ts
+++ b/packages/snap/src/rpc/estimateMessageGas.ts
@@ -24,8 +24,6 @@ export async function estimateMessageGas(
     method: 0, // code for basic transaction
     nonce: 0, // dummy nonce just for gas calculation
   };
-  // estimate gas usage
-  const gasLimit = await api.gasEstimateGasLimit(message, null);
   // set max fee to 0.1 FIL if not set
   const maxFeeAttoFil = maxFee
     ? maxFee
@@ -37,7 +35,7 @@ export async function estimateMessageGas(
   );
   return {
     gasfeecap: messageEstimate.GasFeeCap,
-    gaslimit: gasLimit,
+    gaslimit: messageEstimate.GasLimit,
     gaspremium: messageEstimate.GasPremium,
     maxfee: maxFeeAttoFil,
   };

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -59,12 +59,12 @@ export async function signMessage(
       message.gasfeecap === "0" &&
       message.gaspremium === "0"
     ) {
-      message.gaslimit = await api.gasEstimateGasLimit(message, null);
       const messageEstimate = await api.gasEstimateMessageGas(
         message,
         { MaxFee: "0" },
         null
       );
+      message.gaslimit = messageEstimate.GasLimit;
       message.gaspremium = messageEstimate.GasPremium;
       message.gasfeecap = messageEstimate.GasFeeCap;
     }

--- a/packages/snap/test/unit/rpc/signMessage.test.ts
+++ b/packages/snap/test/unit/rpc/signMessage.test.ts
@@ -49,10 +49,10 @@ describe("Test rpc handler function: signMessage", function () {
     walletStub.prepareFoKeyPair();
 
     apiStub.mpoolGetNonce.returns("0");
-    apiStub.gasEstimateGasLimit.returns(1000);
     apiStub.gasEstimateMessageGas.returns({
       GasPremium: "10",
       GasFeeCap: "10",
+      GasLimit: 1000,
     });
 
     const response = await signMessage(walletStub, apiStub, messageRequest);
@@ -61,7 +61,6 @@ describe("Test rpc handler function: signMessage", function () {
     expect(walletStub.rpcStubs.snap_getBip44Entropy).to.have.been.calledOnce;
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.calledOnce;
     expect(apiStub.mpoolGetNonce).to.have.been.calledOnce;
-    expect(apiStub.gasEstimateGasLimit).to.have.been.calledOnce;
     expect(apiStub.gasEstimateMessageGas).to.have.been.calledOnce;
     expect(response.signedMessage.message).to.be.deep.eq(fullMessage);
     expect(response.signedMessage.signature.data).to.not.be.empty;
@@ -103,10 +102,10 @@ describe("Test rpc handler function: signMessage", function () {
     walletStub.rpcStubs.snap_confirm.resolves(true);
     walletStub.prepareFoKeyPair();
     apiStub.mpoolGetNonce.returns("0");
-    apiStub.gasEstimateGasLimit.returns(1000);
     apiStub.gasEstimateMessageGas.returns({
       GasFeeCap: "10",
       GasPremium: "10",
+      GasLimit: 1000,
     });
 
     const messageRequestWithCustomParams: MessageRequest = {
@@ -123,7 +122,6 @@ describe("Test rpc handler function: signMessage", function () {
     expect(walletStub.rpcStubs.snap_getBip44Entropy).to.have.been.calledOnce;
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.calledOnce;
     expect(apiStub.mpoolGetNonce).to.have.been.calledOnce;
-    expect(apiStub.gasEstimateGasLimit).to.have.been.calledOnce;
     expect(apiStub.gasEstimateMessageGas).to.have.been.calledOnce;
     expect(response.signedMessage.message).to.be.deep.eq(paramsMessage);
     expect(response.signedMessage.signature.data).to.not.be.empty;


### PR DESCRIPTION
Fixed gasLimit estimation in `estimateMessageGas` and `signMessage` by using `gasEstimateMessageGas` method directly instead of calling `gasEstimateGasLimit`which failed saying it didnt exist. 